### PR TITLE
Adjust license name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ If you want to understand the code, develop, or contribute. Please visit
 
 ## License
 
-[License](LICENSE.md) - Apache v2 License
+[License](LICENSE.md) - MIT License


### PR DESCRIPTION
LICENSE.md indicates that the library is licensed under MIT License. However, the README.md states it is Apache 2.0. This PR is simply adjusting the README.md.