### PR TITLE
Warn if a plain socket (instead of a factory) is passed to Stomp.over

### DIFF
--- a/spec/unit/compatibility/connection.spec.js
+++ b/spec/unit/compatibility/connection.spec.js
@@ -13,7 +13,16 @@ describe("Compat Stomp Connection", function () {
       });
   });
 
-  it("Connect to a valid Stomp server using Stomp.over", function (done) {
+  it("Connect to a valid Stomp server using Stomp.over (plain socket)", function (done) {
+    const socket= new WebSocket(TEST.url);
+    client = StompJs.Stomp.over(socket);
+    client.connect(TEST.login, TEST.password,
+      function () {
+        done();
+      });
+  });
+
+  it("Connect to a valid Stomp server using Stomp.over (socket factory)", function (done) {
     const socketFactory = function () {
       return new WebSocket(TEST.url);
     };
@@ -22,6 +31,16 @@ describe("Compat Stomp Connection", function () {
       function () {
         done();
       });
+  });
+
+  it("Should warn if factory was not supplied to Stomp.over", function () {
+    const socket= new WebSocket(TEST.url);
+
+    const spy = spyOn(console, 'warn').and.callThrough();
+
+    client = StompJs.Stomp.over(socket);
+
+    expect(spy).toHaveBeenCalled();
   });
 
 });

--- a/src/compatibility/stomp.ts
+++ b/src/compatibility/stomp.ts
@@ -90,7 +90,15 @@ export class Stomp {
    * using [Client#webSocketFactory]{@link Client#webSocketFactory}.
    */
   public static over(ws: any): CompatClient {
-    const wsFn = typeof(ws) === 'function' ? ws : () => ws;
+    let wsFn: () => any;
+
+    if (typeof (ws) === 'function') {
+      wsFn = ws;
+    } else {
+      console.warn('Stomp.over did not receive a factory, auto reconnect will not work. ' +
+        'Please see https://stomp-js.github.io/api-docs/latest/classes/Stomp.html#over');
+      wsFn = () => ws;
+    }
 
     return new CompatClient(wsFn);
   }


### PR DESCRIPTION
Fixes #116 