### PR TITLE
Make tests compliant to RabbitMQ 3.8.8

### DIFF
--- a/spec/unit/callbacks.spec.js
+++ b/spec/unit/callbacks.spec.js
@@ -14,7 +14,6 @@ describe('Callbacks', function () {
       const expectedSeq = [
         'before connect',
         'on connect',
-        'on disconnect',
         'websocket close',
       ];
       let seq = [];
@@ -27,7 +26,8 @@ describe('Callbacks', function () {
         seq.push('before connect');
       };
       client.onDisconnect = function () {
-        seq.push('on disconnect');
+        console.log('Optional callback, not every broker will acknowledge DISCONNECT');
+        // seq.push('on disconnect');
       };
       client.onWebSocketClose = function () {
         seq.push('websocket close');
@@ -77,7 +77,6 @@ describe('Callbacks', function () {
         'websocket close', // first cycle
         'before connect',
         'on connect',
-        'on disconnect',
         'websocket close',
       ]; // send cycle
       let seq = [];
@@ -97,7 +96,8 @@ describe('Callbacks', function () {
         seq.push('before connect');
       };
       client.onDisconnect = function () {
-        seq.push('on disconnect');
+        console.log('Optional callback, not every broker will acknowledge DISCONNECT');
+        // seq.push('on disconnect');
       };
       client.onWebSocketClose = function () {
         seq.push('websocket close');

--- a/spec/unit/config.spec.js
+++ b/spec/unit/config.spec.js
@@ -26,7 +26,7 @@ describe('Configuration', function () {
           disconnectHeaders: {
             myheader: headerAfterConnect,
           },
-          onDisconnect: function () {
+          onWebSocketClose: function () {
             const rawChunk = spy.calls.first().args[0];
             expect(rawChunk).not.toMatch(headerBeforeConnect);
             expect(rawChunk).toMatch(headerAfterConnect);
@@ -68,7 +68,7 @@ describe('Configuration', function () {
       onConnect: function () {
         client.deactivate();
       },
-      onDisconnect: function () {
+      onWebSocketClose: function () {
         expect(disconnectHeaders).toEqual(disconnectHeadersOrig);
         done();
       },

--- a/spec/unit/connection.spec.js
+++ b/spec/unit/connection.spec.js
@@ -53,7 +53,7 @@ describe('Stomp Connection', function () {
         // once connected, we disconnect
         client.deactivate();
       },
-      onDisconnect: function () {
+      onWebSocketClose: function () {
         done();
       },
     });
@@ -115,8 +115,8 @@ describe('Stomp Connection', function () {
         // once connected, we disconnect
         client.deactivate();
       },
-      onDisconnect: function () {
-        client.onDisconnect = function () {};
+      onWebSocketClose: function () {
+        client.onWebSocketClose = function () {};
         client.onConnect = function () {
           done();
         };

--- a/spec/unit/reconnect.spec.js
+++ b/spec/unit/reconnect.spec.js
@@ -48,7 +48,7 @@ describe('Stomp Reconnect', function () {
   it('Should allow disconnecting when auto reconnection is on', function (done) {
     const num_try = 1;
 
-    let disconnectCallbackCalled = false;
+    let connectionClosed = false;
 
     client.configure({
       reconnectDelay: 300,
@@ -58,15 +58,17 @@ describe('Stomp Reconnect', function () {
         client.deactivate();
       },
       onDisconnect: function () {
-        expect(client.connected).toBe(false);
-        disconnectCallbackCalled = true;
+        console.log('Optional callback, not every broker will acknowledge DISCONNECT');
       },
+      onWebSocketClose: function () {
+        connectionClosed = true;
+      }
     });
 
     client.activate();
 
     setTimeout(function () {
-      expect(disconnectCallbackCalled).toBe(true);
+      expect(connectionClosed).toBe(true);
       expect(client.connected).toBe(false);
 
       done();


### PR DESCRIPTION
It is optional for a broker to acknowledge the DISCONNECT frame before dropping the connection. RabbitMQ 3.7.7 (and before that) used to acknowledge, however 3.8.8 does not.