### PR TITLE
enhance connection timeout process

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -416,7 +416,14 @@ export class Client {
 
     // setup connection watcher
     if (this.connectionTimeout > 0) {
+      // clear first
+      if (this._connectionWatcher) {
+        clearTimeout(this._connectionWatcher);
+      }
       this._connectionWatcher = setTimeout(() => {
+        if (this.connected) {
+          return;
+        }
         // Connection not established, close the underlying socket
         // a reconnection will be attempted
         this.debug(


### PR DESCRIPTION
Connection timeout watcher might not be clear when establishing error occur, and it will force connection established by retry process.