### PR TITLE
Pass client in beforeConnect

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -221,7 +221,7 @@ export class Client {
    * This can be used to reliably fetch credentials, access token etc. from some other service
    * in an asynchronous way.
    */
-  public beforeConnect: () => void | Promise<void>;
+  public beforeConnect: (client: Client) => void | Promise<void>;
 
   /**
    * Callback, invoked on every successful connection to the STOMP broker.
@@ -408,7 +408,7 @@ export class Client {
   }
 
   private async _connect(): Promise<void> {
-    await this.beforeConnect();
+    await this.beforeConnect(this);
 
     if (this._stompHandler) {
       this.debug('There is already a stompHandler, skipping the call to connect');


### PR DESCRIPTION
I'm facing the same issue as https://github.com/stomp-js/rx-stomp/issues/204 in the rx-stomp library:

We are using access tokens with a short lifetime of ~5 minutes and passing these tokens as a connect header on the initial CONNECT message. If the websocket connection breaks after the access token is expired, it is not possible to supply a refreshed access token, the expired token is still used on the reconnnect. Of course, that reconnect fails because the old token is expired. In the linked issue, the problem was fixed by passing the client object to the `beforeConnect` callback, I've done the same here.

Feel free to comment on, or edit my changes!

Best
Nikos