### PR TITLE
ci: Set default workflow permissions to read-only

### DIFF
--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -8,6 +8,9 @@ on:
       - master
       - develop
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     # The type of runner that the job will run on

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,9 @@ name: Firefox, Chrome
 # or API.
 on: [push, pull_request]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     # The type of runner that the job will run on

--- a/.github/workflows/node-js.yml
+++ b/.github/workflows/node-js.yml
@@ -6,6 +6,9 @@ name: NodeJS Test
 # or API.
 on: [push, pull_request]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     # The type of runner that the job will run on

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,6 +6,9 @@ name: Safari
 # or API.
 on: [push, pull_request]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     # The type of runner that the job will run on


### PR DESCRIPTION
Declare default permissions as read-only for all jobs in the workflow to follow the principle of least privilege. This enhances security by limiting the permissions available to the actions run within this workflow.

    permissions: read-all

This change ensures that any action in this workflow can only read repository data unless explicitly granted write access. Explicit permission settings for specific jobs or steps should be used when write access is required.