### PR TITLE
Fix typos in JSDoc comments across multiple functions

### DIFF
--- a/bundles/stomp.umd.js
+++ b/bundles/stomp.umd.js
@@ -1056,7 +1056,7 @@
              * client.configure({
              *   reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
              *   reconnectDelay: 200, // It will wait 200, 400, 800 ms...
-             *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more that these ms
+             *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more than these ms
              * })
              * ```
              */
@@ -1455,7 +1455,7 @@
          * The value (say receipt-id) for this header needs to be unique for each use.
          * Typically, a sequence, a UUID, a random number or a combination may be used.
          *
-         * A complaint broker will send a RECEIPT frame when an operation has actually been completed.
+         * A compliant broker will send a RECEIPT frame when an operation has actually been completed.
          * The operation needs to be matched based on the value of the receipt-id.
          *
          * This method allows watching for a receipt and invoking the callback

--- a/esm6/client.d.ts
+++ b/esm6/client.d.ts
@@ -82,7 +82,7 @@ export declare class Client {
      * client.configure({
      *   reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
      *   reconnectDelay: 200, // It will wait 200, 400, 800 ms...
-     *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more that these ms
+     *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more than these ms
      * })
      * ```
      */
@@ -199,7 +199,7 @@ export declare class Client {
      * Callback, invoked on before a connection to the STOMP broker.
      *
      * You can change options on the client, which will impact the immediate connecting.
-     * It is valid to call [Client#decativate]{@link Client#deactivate} in this callback.
+     * It is valid to call [Client#deactivate]{@link Client#deactivate} in this callback.
      *
      * As of version 5.1, this callback can be
      * [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
@@ -405,7 +405,7 @@ export declare class Client {
      * The value (say receipt-id) for this header needs to be unique for each use.
      * Typically, a sequence, a UUID, a random number or a combination may be used.
      *
-     * A complaint broker will send a RECEIPT frame when an operation has actually been completed.
+     * A compliant broker will send a RECEIPT frame when an operation has actually been completed.
      * The operation needs to be matched based on the value of the receipt-id.
      *
      * This method allows watching for a receipt and invoking the callback

--- a/esm6/client.js
+++ b/esm6/client.js
@@ -89,7 +89,7 @@ export class Client {
          * client.configure({
          *   reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
          *   reconnectDelay: 200, // It will wait 200, 400, 800 ms...
-         *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more that these ms
+         *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more than these ms
          * })
          * ```
          */
@@ -488,7 +488,7 @@ export class Client {
      * The value (say receipt-id) for this header needs to be unique for each use.
      * Typically, a sequence, a UUID, a random number or a combination may be used.
      *
-     * A complaint broker will send a RECEIPT frame when an operation has actually been completed.
+     * A compliant broker will send a RECEIPT frame when an operation has actually been completed.
      * The operation needs to be matched based on the value of the receipt-id.
      *
      * This method allows watching for a receipt and invoking the callback

--- a/src/client.ts
+++ b/src/client.ts
@@ -113,7 +113,7 @@ export class Client {
    * client.configure({
    *   reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
    *   reconnectDelay: 200, // It will wait 200, 400, 800 ms...
-   *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more that these ms
+   *   maxReconnectDelay: 10000, // Optional, when provided, it will not wait more than these ms
    * })
    * ```
    */
@@ -257,7 +257,7 @@ export class Client {
    * Callback, invoked on before a connection to the STOMP broker.
    *
    * You can change options on the client, which will impact the immediate connecting.
-   * It is valid to call [Client#decativate]{@link Client#deactivate} in this callback.
+   * It is valid to call [Client#deactivate]{@link Client#deactivate} in this callback.
    *
    * As of version 5.1, this callback can be
    * [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
@@ -764,7 +764,7 @@ export class Client {
    * The value (say receipt-id) for this header needs to be unique for each use.
    * Typically, a sequence, a UUID, a random number or a combination may be used.
    *
-   * A complaint broker will send a RECEIPT frame when an operation has actually been completed.
+   * A compliant broker will send a RECEIPT frame when an operation has actually been completed.
    * The operation needs to be matched based on the value of the receipt-id.
    *
    * This method allows watching for a receipt and invoking the callback


### PR DESCRIPTION
- "complaint broker" → "compliant broker"
- "decativate" → "deactivate"
- "more that these ms" → "more than these ms"